### PR TITLE
Enable mesh services

### DIFF
--- a/packaging/debian/postinst
+++ b/packaging/debian/postinst
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-systemctl enable agent_protocol_splitter.service communication_link.service micrortps_agent.service px4_mavlink_ctrl.service mavlink-router.service mesh.service depthai_ctrl.service
+systemctl enable agent_protocol_splitter.service communication_link.service micrortps_agent.service px4_mavlink_ctrl.service mavlink-router.service mesh-init.service mesh.service mesh_pub.service depthai_ctrl.service


### PR DESCRIPTION
New services of mesh package were not enable when service file was installed.