### PR TITLE
protocol-splitter: increate baudrate to 3M

### DIFF
--- a/system/agent_protocol_splitter.service
+++ b/system/agent_protocol_splitter.service
@@ -6,7 +6,7 @@ After=network.target
 Type=simple
 User=sad
 Group=sad
-ExecStart=/usr/bin/protocol_splitter -b 1000000 -d /dev/ttyS7 -x 14540 -w 14580 -y 2019 -z 2020
+ExecStart=/usr/bin/protocol_splitter -b 3000000 -d /dev/ttyS7 -x 14540 -w 14580 -y 2019 -z 2020
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
To fix issue with 2.6MBit/s data stream from PX4->ROS2, the UART baudrate is increased from 1M to 3M