### PR TITLE
Add baudrate to micrortps agent

### DIFF
--- a/system/micrortps_agent.service
+++ b/system/micrortps_agent.service
@@ -7,7 +7,7 @@ After=mesh-init.service
 Type=simple
 User=sad
 Group=sad
-ExecStart=/bin/sh -c ". /opt/ros/galactic/setup_fog.sh; micrortps_agent -t UDP -r 2020 -s 2019 -n $DRONE_DEVICE_ID -a 127.0.0.1"
+ExecStart=/bin/sh -c ". /opt/ros/galactic/setup_fog.sh; micrortps_agent -b 1000000 -t UDP -r 2020 -s 2019 -n $DRONE_DEVICE_ID -a 127.0.0.1"
 Restart=on-failure
 RestartSec=1s
 

--- a/vm-main/system/micrortps_agent.service
+++ b/vm-main/system/micrortps_agent.service
@@ -6,7 +6,7 @@ After=network.target
 Type=simple
 User=sad
 Group=sad
-ExecStart=/bin/sh -c ". /opt/ros/galactic/setup_fog.sh; micrortps_agent -t UDP -r 2020 -s 2019 -n $DRONE_DEVICE_ID"
+ExecStart=/bin/sh -c ". /opt/ros/galactic/setup_fog.sh; micrortps_agent -b 1000000 -t UDP -r 2020 -s 2019 -n $DRONE_DEVICE_ID -a 127.0.0.1"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The baud rate is used in time delay calculation. Defaults to 460800, which causes wrong time stamp calculation.

```
 -b <baudrate>  UART device baudrate. Defaults to 460800. Used for transmission delay also in UDP case"
```